### PR TITLE
Tag insertion duplicates value: Removed all tags before adding news, this avoid duplication.

### DIFF
--- a/GifWallet/ViewControllers/GIFDetailsViewController.swift
+++ b/GifWallet/ViewControllers/GIFDetailsViewController.swift
@@ -203,6 +203,7 @@ extension GIFDetailsViewController: ViewModelConfigurable {
             self.imageAspectRatioConstraint.priority = .defaultHigh
             self.imageAspectRatioConstraint.isActive = true
         }
+        self.tagView.removeAllTags()
         self.tagView.addTags(Array(vm.tags))
     }
 }

--- a/GifWallet/Views/Input Views/TagInputView.swift
+++ b/GifWallet/Views/Input Views/TagInputView.swift
@@ -67,6 +67,7 @@ final class TagsInputView: UIView, ViewModelConfigurable {
     }
 
     func configureFor(vm: VM) {
+        tagView.removeAllTags()
         tagView.addTags(vm.tags)
         minHeightAnchor.isActive = (vm.tags.count == 0)
     }


### PR DESCRIPTION
I have checked the TagView library and they permit to add the same tag more then once.
To avoid the duplication we can call the removeAllTags function.